### PR TITLE
Add Feature: Make Rail Tankers in transit display their cargo contents with an icon in alt-view as well as in mouseover

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -185,7 +185,7 @@ function findTankers(show)
         add_manualTanker(tanker)
       end
     else
-      on_entitiy_built({created_entity=ent})
+      on_entity_built({created_entity=ent})
       found = found+1
     end
   end
@@ -297,7 +297,7 @@ script.on_event(defines.events.on_preplayer_mined_item, on_entity_removed)
 script.on_event(defines.events.on_robot_pre_mined, on_entity_removed)
 script.on_event(defines.events.on_entity_died, on_entity_removed)
 
-on_entitiy_built = function(event)
+on_entity_built = function(event)
   local _, err = pcall(function()
     local entity = event.created_entity
     if isTankerEntity(entity) then
@@ -328,8 +328,8 @@ on_entitiy_built = function(event)
   if err then debugLog(err,true, global.version) end
 end
 
-script.on_event(defines.events.on_built_entity, on_entitiy_built)
-script.on_event(defines.events.on_robot_built_entity, on_entitiy_built)
+script.on_event(defines.events.on_built_entity, on_entity_built)
+script.on_event(defines.events.on_robot_built_entity, on_entity_built)
 
 on_train_changed_state = function(event)
   local _, err = pcall(function()

--- a/control.lua
+++ b/control.lua
@@ -114,20 +114,18 @@ on_tick = function(event)
     script.on_event(defines.events.on_tick, nil)
     return
   end
-  if event.tick % 20 == 16 then
-    for i=#global.manualTankers,1,-1 do
-      local tanker = global.manualTankers[i]
-      if isValid(tanker.entity) then
-        if isTankerMoving(tanker) then
-          Proxy.pickup(tanker)
-		  addFluidItems(tanker)
-        elseif tanker.proxy == nil then
-          Proxy.create(tanker)
-		  tanker.entity.clear_items_inside()
-        end
-      else
-        table.remove(global.manualTankers,i)
+  for i=#global.manualTankers,1,-1 do
+    local tanker = global.manualTankers[i]
+    if isValid(tanker.entity) then
+      if isTankerMoving(tanker) then
+        Proxy.pickup(tanker)
+	    addFluidItems(tanker)
+      elseif tanker.proxy == nil then
+        Proxy.create(tanker)
+	    tanker.entity.clear_items_inside()
       end
+    else
+      table.remove(global.manualTankers,i)
     end
   end
 end

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,3 +1,16 @@
 if data.raw["pump"]["small-pump"] then
   data.raw["pump"]["small-pump"].collision_box = {{-0.29, -0.29}, {0.29, 0.29}}
 end
+
+for i, fluid in pairs(data.raw["fluid"]) do
+	local fluid_item = {
+		type = "item",
+		name = fluid.name .. "-in-tanker",
+		icon = fluid.icon,
+		flags = {"goes-to-main-inventory", "hidden"},
+		subgroup = "transport",
+		order = "z[rail-tanker]",
+		stack_size = 2500
+	}
+	data:extend({fluid_item})
+end

--- a/prototypes/entity/entities.lua
+++ b/prototypes/entity/entities.lua
@@ -5,7 +5,7 @@ data:extend(
     name = "rail-tanker",
 	icon = "__RailTanker__/graphics/rail-tanker.png",
     flags = {"placeable-neutral", "player-creation", "placeable-off-grid"},
-    inventory_size = 0,
+    inventory_size = 1,
     minable = {mining_time = 1, result = "rail-tanker"},
     max_health = 600,
     corpse = "medium-remnants",

--- a/prototypes/entity/entities.lua
+++ b/prototypes/entity/entities.lua
@@ -41,7 +41,7 @@ data:extend(
       line_length = 4,
       lines_per_file = 8,
       shift={1.93, -0.38}
-	  
+
     },
 	--scale=20,
     rail_category = "regular"
@@ -65,31 +65,31 @@ data:extend(
       --pipe_covers = pipecoverspictures(),
       pipe_connections =
       {
-	  
-	  
+
+
 		{ position = {0.4, -1.2} },
 		{ position = {-0.4, -1.2} },
 		-- { position = {1, -1.2} },
 		-- { position = {-1, -1.2} },
-		
+
        { position = {-0.4, 1.2} },
        { position = {0.4, 1.2} },
         -- { position = {1, 1.2} },
         -- { position = {-1, 1.2} },
-		
-		
+
+
         { position = {1.2, 0.4} },
         { position = {1.2, -0.4} },
         -- { position = {1.2, 1} },
         -- { position = {1.2, -1} },
-		
-		
+
+
         { position = {-1.2, 0.4} },
         { position = {-1.2, -0.4} },
         -- { position = {-1.2, 1} },
         -- { position = {-1.2, -1} },
-		
-		
+
+
       },
     },
 	window_bounding_box = {{-0.125, 0.6875}, {0.1875, 1.1875}},
@@ -194,7 +194,7 @@ data:extend(
 
     circuit_wire_max_distance = 0
   },
-  
+
   {
     type = "storage-tank",
     name = "rail-tanker-proxy-noconnect",
@@ -213,7 +213,7 @@ data:extend(
       -- pipe_covers = pipecoverspictures(),
       pipe_connections =
       {
-		
+
       },
     },
     window_bounding_box = {{-0.125, 0.6875}, {0.1875, 1.1875}},


### PR DESCRIPTION
Some aesthetic fixes applied as well, typo fix and whitespace trimming.

Changing on_tick to run its checks every tick was needed as well, because inserters seemed to be able to pull items out from a manual-mode rail tanker in the split second between when it stopped and the every-20-ticks check ran. According to my benchmarks, performance was only very slightly decreased, and on_tick only runs when a rail tanker train is in manual mode, which should really not happen very often at all.
