### PR TITLE
Use proper order tag for rail tanker item

### DIFF
--- a/prototypes/item/items.lua
+++ b/prototypes/item/items.lua
@@ -6,7 +6,7 @@ data:extend(
       icon = "__RailTanker__/graphics/rail-tanker.png",
       flags = {"goes-to-quickbar"},
       subgroup = "transport",
-      order = "a[train-system]-f[rail-tanker]-z",
+      order = "a[train-system]-g[rail-tanker]-z",
       place_result = "rail-tanker",
       stack_size = 5
     },


### PR DESCRIPTION
The order group `a[train-system]-f` is/should be reserved for locomotives.
Otherwise its hard to add other locomotives to the right location.
Thats why I suggest moving the rail tanker to `a[train-system]-g` which is the same group as the default cargo wagon.

Current item order:
![olditemorder](https://cloud.githubusercontent.com/assets/1579362/15634341/b1cca83c-25c1-11e6-809e-7c7cbd1b8047.png)
A) Diesel-locomotive (Base)
B) Rail tanker (this mod)
C) Shuttle train ([Shuttle-Train](https://github.com/simwir/Shuttle-Train))
D) Cargo wagon (Base)

New item order:
![newitemorder](https://cloud.githubusercontent.com/assets/1579362/15634343/b97aa5c0-25c1-11e6-8f06-6c2f15f6f62c.png)

Related: https://github.com/simwir/Shuttle-Train/issues/22
