### PR TITLE
Made proxies undestructible and made neutral force

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -83,7 +83,8 @@ Proxy.create = function(tanker, found_pump)
   else
     proxyName = "rail-tanker-proxy"
   end
-  local foundProxy = surface.create_entity{name=proxyName, position=position, force=tanker.entity.force}
+  local foundProxy = surface.create_entity{name=proxyName, position=position, force=game.forces["neutral"] or tanker.entity.force}
+  foundProxy.destructible = false
   --local foundProxy = Proxy.find(position)
   foundProxy.fluidbox[1] = fluidbox
   --debugLog(game.tick .. " created " .. foundProxy.name)


### PR DESCRIPTION
This caused some issues if a tanker has been attacked and only the proxy
was destroyed. Trains could get stuck at stations because they couldn't
unload the liquid.
Also when it's in the neutral force biters shouldn't even try attacking
it (I think, haven't tested this one).